### PR TITLE
Backport localization support for :format option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+version: 2
+
+defaults: &defaults
+  working_directory: ~/repo
+
+  steps:
+    - checkout
+
+    - run:
+        name: Install dependencies
+        command: |
+          bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+    - run:
+        name: Run tests
+        command: |
+          bundle exec rspec --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+
+    - store_test_results:
+        path: /tmp/test-results
+
+    - store_artifacts:
+        path: /tmp/test-results
+        destination: test-results
+
+jobs:
+  "ruby-2.3":
+    <<: *defaults
+    docker:
+      - image: circleci/ruby:2.3
+  "ruby-2.4":
+    <<: *defaults
+    docker:
+      - image: circleci/ruby:2.4
+  "ruby-2.5":
+    <<: *defaults
+    docker:
+      - image: circleci/ruby:2.5
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - "ruby-2.3"
+      - "ruby-2.4"
+      - "ruby-2.5"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'coveralls', '>= 0.8.17', require: false
 gem 'pry', require: false
+gem 'rspec_junit_formatter', require: false
 
 # JSON gem no longer supports ruby < 2.0.0
 if defined?(JRUBY_VERSION)

--- a/lib/money/locale_backend/currency.rb
+++ b/lib/money/locale_backend/currency.rb
@@ -4,7 +4,11 @@ class Money
   module LocaleBackend
     class Currency < Base
       def lookup(key, currency)
-        currency.public_send(key) if currency.respond_to?(key)
+        if currency.respond_to?(key)
+          currency.public_send(key)
+        elsif key == :format
+          currency.symbol_first? ? '%u%n' : '%n %u'
+        end
       end
     end
   end

--- a/lib/money/locale_backend/i18n.rb
+++ b/lib/money/locale_backend/i18n.rb
@@ -6,6 +6,7 @@ class Money
       KEY_MAP = {
         thousands_separator: :delimiter,
         decimal_mark: :separator,
+        format: :format,
         symbol: :unit
       }.freeze
 
@@ -14,6 +15,8 @@ class Money
       end
 
       def lookup(key, _)
+        return unless KEY_MAP.key?(key)
+
         i18n_key = KEY_MAP[key]
 
         ::I18n.t i18n_key, scope: 'number.currency.format', raise: true

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -168,7 +168,7 @@ class Money
     @use_i18n = true
 
     # Default to using legacy locale backend
-    self.locale_backend = :legacy
+    self.locale_backend = :currency
 
     # Default to not using infinite precision cents
     self.infinite_precision = false

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -5,7 +5,8 @@ class Money
   class Formatter
     DEFAULTS = {
       thousands_separator: '',
-      decimal_mark: '.'
+      decimal_mark: '.',
+      format: '%u%n'
     }.freeze
 
     # Creates a formatted price string according to several rules.
@@ -293,7 +294,7 @@ class Money
           symbol_value = html_wrap(symbol_value, "currency-symbol")
         end
 
-        rules[:format]
+        lookup(:format)
           .gsub('%u', [sign_before, symbol_value].join)
           .gsub('%n', [sign, formatted_number].join)
       else

--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -11,7 +11,6 @@ class Money
       @rules = default_formatting_rules.merge(@rules) unless @rules[:ignore_defaults]
       @rules = localize_formatting_rules(@rules)
       @rules = translate_formatting_rules(@rules) if @rules[:translate]
-      @rules[:format] ||= determine_format_from_formatting_rules(@rules)
 
       warn_about_deprecated_rules(@rules)
     end
@@ -75,16 +74,6 @@ class Money
         rules[:format] = '%n%u'
       end
       rules
-    end
-
-    def determine_format_from_formatting_rules(rules)
-      symbol_position = symbol_position_from(rules)
-
-      if symbol_position == :before
-        rules.fetch(:symbol_before_without_space, true) ? '%u%n' : '%u %n'
-      else
-        rules[:symbol_after_without_space] ? '%n%u' : '%n %u'
-      end
     end
 
     def symbol_position_from(rules)

--- a/spec/locale_backend/currency_spec.rb
+++ b/spec/locale_backend/currency_spec.rb
@@ -2,14 +2,22 @@
 
 describe Money::LocaleBackend::Currency do
   describe '#lookup' do
-    let(:currency) { Money::Currency.new('EUR') }
+    let(:usd) { Money::Currency.new('USD') }
+    let(:nok) { Money::Currency.new('NOK') }
 
     it 'returns thousands_separator as defined in currency' do
-      expect(subject.lookup(:thousands_separator, currency)).to eq('.')
+      expect(subject.lookup(:thousands_separator, usd)).to eq(',')
+      expect(subject.lookup(:thousands_separator, nok)).to eq('.')
     end
 
-    it 'returns decimal_mark based as defined in currency' do
-      expect(subject.lookup(:decimal_mark, currency)).to eq(',')
+    it 'returns decimal_mark as defined in currency' do
+      expect(subject.lookup(:decimal_mark, usd)).to eq('.')
+      expect(subject.lookup(:decimal_mark, nok)).to eq(',')
+    end
+
+    it 'returns format based on currency' do
+      expect(subject.lookup(:format, usd)).to eq('%u%n')
+      expect(subject.lookup(:format, nok)).to eq('%n %u')
     end
   end
 end

--- a/spec/locale_backend/i18n_spec.rb
+++ b/spec/locale_backend/i18n_spec.rb
@@ -21,7 +21,7 @@ describe Money::LocaleBackend::I18n do
       before do
         I18n.locale = :de
         I18n.backend.store_translations(:de, number: {
-          currency: { format: { delimiter: '.', separator: ',', unit: '$' } }
+          currency: { format: { delimiter: '.', separator: ',', format: '%u %n' } }
         })
       end
 
@@ -33,8 +33,8 @@ describe Money::LocaleBackend::I18n do
         expect(subject.lookup(:decimal_mark, nil)).to eq(',')
       end
 
-      it 'returns symbol based on the current locale' do
-        expect(subject.lookup(:symbol, nil)).to eq('$')
+      it 'returns format based on the current locale' do
+        expect(subject.lookup(:format, nil)).to eq('%u %n')
       end
     end
 
@@ -51,6 +51,10 @@ describe Money::LocaleBackend::I18n do
       it 'returns decimal_mark based on the current locale' do
         expect(subject.lookup(:decimal_mark, nil)).to eq(',')
       end
+
+      it 'returns nil for format' do
+        expect(subject.lookup(:format, nil)).to eq(nil)
+      end
     end
 
     context 'with no translation defined' do
@@ -64,6 +68,10 @@ describe Money::LocaleBackend::I18n do
 
       it 'returns symbol based on the current locale' do
         expect(subject.lookup(:symbol, nil)).to eq(nil)
+      end
+
+      it 'returns nil for format' do
+        expect(subject.lookup(:format, nil)).to eq(nil)
       end
     end
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -2,7 +2,7 @@
 
 describe Money do
   describe '.locale_backend' do
-    after { Money.locale_backend = :legacy }
+    after { Money.locale_backend = :currency }
 
     it 'sets the locale_backend' do
       Money.locale_backend = :i18n
@@ -512,7 +512,7 @@ YAML
       expect(Money.new(10_00, "BRL").to_s).to eq "10,00"
     end
 
-    context "using i18n" do
+    context "using i18n", :i18n do
       before { I18n.backend.store_translations(:en, number: { format: { separator: "." } }) }
       after { reset_i18n }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,17 @@ def reset_i18n
   I18n.backend = I18n::Backend::Simple.new
 end
 
+RSpec.shared_context 'with i18n locale backend', :i18n do
+  around do |example|
+    previous_locale_backend = Money.locale_backend
+    Money.locale_backend = :i18n
+
+    example.run
+
+    Money.locale_backend = Money::LocaleBackend::BACKENDS.key(previous_locale_backend.class)
+  end
+end
+
 RSpec.shared_context "with infinite precision", :infinite_precision do
   before do
     Money.infinite_precision = true


### PR DESCRIPTION
This allows I18n to provide a template for formatting.

This is an implementation of the following PR, but on top of v6.13.2
instead of v7: https://github.com/RubyMoney/money/pull/825